### PR TITLE
Run free automated tests on Linux and MacOSX using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 group: travis_latest
+dist: xenial  # required for Python 3.7
+sudo: true    # required for Python 3.7
 language: python
 cache: pip
 os:
@@ -6,7 +8,7 @@ os:
   - osx
 python:
   - 2.7
-  - 3.6
+  - 3.7
   - pypy
   - pypy3
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ cache: pip
 python:
   #- 2.7
   - 3.7
+  - pypy
+  - pypy2
   - pypy2.7
-  - pypy3.5
+  #- pypy3.5
   #- nightly
 matrix:
   allow_failures:
@@ -18,8 +20,8 @@ matrix:
 install:
   - pip install flake8  # pytest  # add another testing frameworks later
 script:
-  - IGNORE=E115,E122,E127,E128,E131,E201,E2,E401,E402,E501,E722,F403,F841
-  - flake8 . --count --ignore=$IGNORE --max-complexity=10 --max-line-length=127 --show-source --statistics
+  - IGNORE=E115,E122,E126,E127,E128,E131,E2,E401,E402,E501,E722,F403,F841
+  - flake8 . --count --ignore=$IGNORE --max-complexity=41 --max-line-length=127 --show-source --statistics
   - python setup.py test
 notifications:
   on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 group: travis_latest
-dist: xenial  # required for Python 3.7
-sudo: true    # required for Python 3.7
+#dist: xenial  # required for Python 3.7
+#sudo: true    # required for Python 3.7
 language: python
 cache: pip
 #os:  # disable osx for now
@@ -10,8 +10,8 @@ python:
   - 2.7
   #- 3.4
   #- 3.5
-  #- 3.6
-  - 3.7
+  - 3.6
+  #- 3.7
   #- pypy
   #- pypy2
   #- pypy2.7  # Can't find the right incantation for PyPy 2.7
@@ -23,13 +23,10 @@ matrix:
 install:
   - pip install flake8  # pytest  # add another testing frameworks later
 script:
-  - python -c "import platform ; print(platform.architecture(), platform.platform(), platform.uname())"
+  - python -c "import platform ; print(platform.platform(), platform.architecture(), platform.uname())"
   - IGNORE=E115,E122,E126,E127,E128,E131,E2,E401,E402,E501,E722,F403,F841
   - flake8 . --count --ignore=$IGNORE --max-complexity=41 --max-line-length=127 --show-source --statistics
   - python setup.py test
-  - cd testresults
-  - ls
-  - cat *
 notifications:
   on_success: change
   on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,23 @@ dist: xenial  # required for Python 3.7
 sudo: true    # required for Python 3.7
 language: python
 cache: pip
-os:
-  - linux
-  - osx
+#os:  # disable osx for now
+#  - linux
+#  - osx
 python:
-  - 2.7
+  #- 2.7
   - 3.7
-  - pypy
-  - pypy3
-  - nightly
+  - pypy2.7
+  - pypy3.5
+  #- nightly
 matrix:
   allow_failures:
     - python: nightly
 install:
   - pip install flake8  # pytest  # add another testing frameworks later
 script:
-  - flake8 . --count --max-complexity=10 --show-source --statistics
+  - IGNORE=E115,E122,E127,E128,E131,E201,E2,E401,E402,E501,E722,F403,F841
+  - flake8 . --count --ignore=$IGNORE --max-complexity=10 --max-line-length=127 --show-source --statistics
   - python setup.py test
 notifications:
   on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
   - python -c "import platform ; print(platform.platform(), platform.architecture(), platform.uname())"
   - IGNORE=E115,E122,E126,E127,E128,E131,E2,E401,E402,E501,E722,F403,F841
   - flake8 . --count --ignore=$IGNORE --max-complexity=41 --max-line-length=127 --show-source --statistics
-  - python setup.py test
+  - python test/run.py -results
 notifications:
   on_success: change
   on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+group: travis_latest
+language: python
+cache: pip
+os:
+  - linux
+  - osx
+python:
+  - 2.7
+  - 3.6
+  - pypy
+  - pypy3
+  - nightly
+matrix:
+  allow_failures:
+    - python: nightly
+install:
+  - pip install flake8  # pytest  # add another testing frameworks later
+script:
+  - flake8 . --count --max-complexity=10 --show-source --statistics
+  - python setup.py test
+notifications:
+  on_success: change
+  on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,16 @@ cache: pip
 #  - linux
 #  - osx
 python:
-  #- 2.7
+  - 2.7
+  #- 3.4
+  #- 3.5
+  #- 3.6
   - 3.7
-  - pypy
-  - pypy2
-  - pypy2.7
-  #- pypy3.5
-  #- nightly
+  #- pypy
+  #- pypy2
+  #- pypy2.7  # Can't find the right incantation for PyPy 2.7
+  - pypy3.5
+  - nightly
 matrix:
   allow_failures:
     - python: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,13 @@ matrix:
 install:
   - pip install flake8  # pytest  # add another testing frameworks later
 script:
-  - python -c "import platform ; print(platform.platform())"
+  - python -c "import platform ; print(platform.architecture(), platform.platform(), platform.uname())"
   - IGNORE=E115,E122,E126,E127,E128,E131,E2,E401,E402,E501,E722,F403,F841
   - flake8 . --count --ignore=$IGNORE --max-complexity=41 --max-line-length=127 --show-source --statistics
   - python setup.py test
+  - cd testresults
   - ls
-  - cat testresults
+  - cat *
 notifications:
   on_success: change
   on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,12 @@ matrix:
 install:
   - pip install flake8  # pytest  # add another testing frameworks later
 script:
+  - python -c "import platform ; print(platform.platform())"
   - IGNORE=E115,E122,E126,E127,E128,E131,E2,E401,E402,E501,E722,F403,F841
   - flake8 . --count --ignore=$IGNORE --max-complexity=41 --max-line-length=127 --show-source --statistics
   - python setup.py test
+  - ls
+  - cat testresults
 notifications:
   on_success: change
   on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
Travis CI can be used to do automated testing on all pull requests before they are reviewed and merged. This service is free to open source projects like this one.  For this to work, @mrJean1 would need to turn on the switch for this repo at https://www.travis-ci.com/mrJean1 (login via GitHub credentials)