### PR TITLE
Reset shared _eF to the meridian modulus in GeodesicExact.Inverse

### DIFF
--- a/pygeodesy/geodesicx/gx.py
+++ b/pygeodesy/geodesicx/gx.py
@@ -579,6 +579,14 @@ class GeodesicExact(_GeodesicBase):
         p = _PDict(sbet1=sbet1, cbet1=cbet1, dn1=self._dn(sbet1, cbet1),
                    sbet2=sbet2, cbet2=cbet2, dn2=self._dn(sbet2, cbet2))
 
+        # C++ GeodesicExact::GenInverse uses a fresh, local EllipticFunction
+        # E(-ep2) per call; here _eF is a shared, cached instance attr, so
+        # restore it to that meridian default (alpha0 == 0 => k2 == ep2).  The
+        # meridian branch below and the prolate _InverseStart6 branch read _eF
+        # without resetting it (unlike the Newton and oblate paths), so without
+        # this a prior non-meridian Inverse leaks its k2 into these results.
+        self._eF.reset(k2=-self.ep2)
+
         _meridian = _b = True  # i.e. meridian = b = False
         if lat1 == -90 or slam12 == 0:
             # Endpoints are on a single full meridian,

--- a/test/testGeodesicx.py
+++ b/test/testGeodesicx.py
@@ -188,6 +188,45 @@ class Tests(TestsBase):
         t = str(gX.Inverse1(40.6, -73.8, 51.6, -0.5))  # coverage
         self.test(gX.Inverse1.__name__, t, t)
 
+    def testInverseMeridian(self, geodesicx, E, debug=False):
+        self.subtitle(geodesicx, 'InverseX meridian state')
+        # A GeodesicExact reuses one Elliptic function _eF across Inverse
+        # calls.  A prior non-meridian Inverse must not leak its modulus into
+        # a later meridian (lon12 = 0) or anti-meridian (lon12 = 180) one:
+        # each must match a fresh instance (and geographiclib) exactly.
+        gX = E.geodesicx  # the shared, cached instance
+        gX.debug = debug
+        M  = gX.STANDARD | gX.REDUCEDLENGTH | gX.GEODESICSCALE
+        nl = 1
+        for lon2 in (0, 180):
+            for lat1, lat2 in ((0, 89), (-30, 60), (89, -89),
+                               (10, -80), (-89, 7), (45, -44)):
+                rf = gX.classof(E.a, E.f).Inverse(lat1, 0, lat2, lon2, outmask=M)
+                gX.Inverse(40.6, -73.8, 51.6, -0.5, outmask=M)  # poison _eF
+                rx = gX.Inverse(lat1, 0, lat2, lon2, outmask=M)
+                t = '(%s, %s, lon2=%s)' % (lat1, lat2, lon2)
+                self.test('s12 ' + t, rx.s12, rf.s12, fmt=_G, nl=nl)
+                self.test('m12 ' + t, rx.m12, rf.m12, fmt=_G)
+                self.test('M12 ' + t, rx.M12, rf.M12, fmt=_G)
+                self.test('M21 ' + t, rx.M21, rf.M21, fmt=_G)
+                nl = 0
+                if geographiclib and lat1 == 0 and lat2 == 89:  # oracle, to mm
+                    rP = E.geodesic.Inverse(lat1, 0, lat2, lon2, outmask=E.geodesic.ALL)
+                    self.test('s12 geographiclib ' + t, round(rx.s12, 3), round(rP.s12, 3))
+                    self.test('m12 geographiclib ' + t, round(rx.m12, 3), round(rP.m12, 3))
+
+        # the prolate (f < 0) _InverseStart6 astroid branch also reads _eF
+        # without resetting; a stale modulus there only degrades the Newton
+        # starting guess, so a reused instance must converge as a fresh one.
+        for lat1, lat2, lon2 in ((30, -29.5, 179.5), (10, -9.8, 179.6),
+                                 (45, -44.6, 179.3)):
+            rf = gX.classof(E.a, -E.f).Inverse(lat1, 0, lat2, lon2, outmask=M)
+            gp = gX.classof(E.a, -E.f)
+            gp.Inverse(35, 0, -33, 140, outmask=M)  # poison _eF
+            rx = gp.Inverse(lat1, 0, lat2, lon2, outmask=M)
+            self.test('prolate iteration (%s, %s)' % (lat1, lat2),
+                      rx.iteration, rf.iteration, nl=1 if lat1 == 30 else 0)
+
     def testPlumbTo(self, geodesicx, E, debug=False):
         self.subtitle(geodesicx, 'PlumbTo ...')
         gX = E.geodesicx  # == geodesicx.GeodesicExact(E)
@@ -272,6 +311,8 @@ if __name__ == '__main__':
     t.testDirect(geodesicx, E, debug=_debug)
 
     t.testInverse(geodesicx, E, debug=_debug)
+
+    t.testInverseMeridian(geodesicx, E, debug=_debug)
 
     t.testPolygon(geodesicx, E.geodesicx, nC4=24)
     t.testPolygon(geodesicx, E.geodesicx, nC4=27)


### PR DESCRIPTION
GeodesicExact.Inverse leaks the shared _eF modulus into meridian results

`GeodesicExact` caches one `Elliptic` function in `self._eF` and reuses it across
`Inverse` calls. The non-meridian Newton path and the oblate `_InverseStart6` branch
reset `_eF` to their geodesic's `k2` before use, but the meridian branch (`lat1 == -90`
or `slam12 == 0`) and the prolate (`f < 0`) `_InverseStart6` branch call `_Length5`
*without* resetting it — they rely on `_eF` still holding the fresh-instance default
`Elliptic(k2=-ep2)` (a meridian has `alpha0 == 0`, so `k2 == ep2`).

That default only holds on a fresh instance. Once the same object has computed any
non-meridian `Inverse`, `_eF` carries that geodesic's `k2`, so a subsequent meridian
(`lon12 == 0`) or anti-meridian (`lon12 == 180`) `Inverse` integrates with the wrong
modulus and returns km-scale-wrong `s12`, `m12` and `M12`/`M21`:

```python
from pygeodesy.geodesicx import GeodesicExact
ge = GeodesicExact()
ge.Inverse(40, -75, 51, 0)                 # any non-meridian inverse
ge.Inverse(0, 0, 89, 0).s12                # 9878569.58  (should be 9890271.86, off 11.7 km)
```

This is the canonical GeographicLib usage — one geodesic object, many `Inverse` calls —
so `Ellipsoids.WGS84.geodesicx` (a shared singleton) is affected too. `Direct*` is immune
(it uses a per-line `_eF`), and `LatLon.distanceTo` is unaffected (it builds a fresh path).

Root cause: C++ `GeodesicExact::GenInverse` constructs a fresh local `EllipticFunction
E(-_ep2)` per call and passes it by reference; the meridian and prolate-`InverseStart`
branches there use it in that `-ep2` state and only the Newton/oblate paths `E.Reset(...)`.
Sharing `E` as a cached `_eF` here dropped that per-call reset. The fix restores it: reset
`_eF` to the meridian default at the start of `_GDictInverse`, mirroring the upstream local
`E(-_ep2)`. This fixes both the meridian branch and the latent prolate `_InverseStart6`
site (where a stale modulus only degraded the Newton starting guess, ~2x more iterations).

Verified against `geographiclib` 2.1: reused-instance meridian and anti-meridian `s12`,
`m12`, `M12`, `M21` now match a fresh instance (and Karney's series) exactly, over a lat
grid for `lon12 in {0, 180}`. Added `testInverseMeridian` to `test/testGeodesicx.py`;
existing `testGeodesicx` / `testEllipsoidalGeodTest` are unchanged.
