### PR TITLE
Use the signed second eccentricity in Ellipsoid._elliptic_e22 (prolate meridian: L, Llat, auxRectifying)

### DIFF
--- a/pygeodesy/ellipsoids.py
+++ b/pygeodesy/ellipsoids.py
@@ -853,7 +853,7 @@ class Ellipsoid(_NamedEnumItem):
     def _elliptic_e22(self):  # aka ._elliptic_ep2
         '''(INTERNAL) Elliptic helper for C{auxRectifying}, C{L}, C{Llat}.
         '''
-        return _MODS.elliptic.Elliptic(-self.e22abs)  # complex
+        return _MODS.elliptic.Elliptic(-self.e22)  # signed, like ._elliptic_e12
 
     equatoradius = a  # Requatorial
 

--- a/test/testEllipsoids.py
+++ b/test/testEllipsoids.py
@@ -138,6 +138,33 @@ class Tests(TestsBase):
             t = '%s [%s]' % (p.name, p.units)
             self.test(t, p, e, fmt='%.3f', known=fabs(p - e) < _TOL)
 
+        # a prolate ellipsoid is WGS84 with the axes swapped, the same meridian
+        # ellipse, so its quarter meridian L equals WGS84's;  the values below
+        # match an independent arc-length oracle.  The unsigned -e22abs modulus
+        # (now -e22) made prolate L, Llat and auxRectifying up to 34% wrong.
+        self.subtitle(ellipsoids, 'Prolate meridian')
+        self.test('L', P.L, E.L, fmt='%.4f')  # same meridian ellipse as WGS84
+        P5 = Ellipsoid(E.a, E.a * 1.5)  # strongly prolate, f=-0.5
+        for Ep, L, plr, Ls, mus in (
+              (P,  '10001965.7293', '40007862.9173',
+                   ('3347892.9098', '5017021.3513', '6681852.3314', '8342976.1399'),
+                   ('30.125114', '60.124852')),
+              (P5, '12648993.4082', '50595973.6329',
+                   ('6525764.1906', '8659673.5804', '10242853.9250', '11514288.8422'),
+                   ('46.432057', '72.879859'))):
+            self.test('L',           Ep.L,           L,   fmt='%.4f')
+            self.test('polarimeter', Ep.polarimeter, plr, fmt='%.4f')
+            for d, s in zip((30, 45, 60, 75), Ls):
+                self.test('Llat(%d)' % d, Ep.Llat(d), s, fmt='%.4f')
+            self.test('Llat(-45)', Ep.Llat(-45), '-' + Ls[1], fmt='%.4f')  # signed
+            for d, s in zip((30, 60), mus):
+                self.test('auxRectifying(%d)' % d, Ep.auxRectifying(d), s, fmt='%.6f')
+                self.test('auxRectifying(%s) inverse' % s,
+                          Ep.auxRectifying(float(s), inverse=True), d, fmt='%.6f')
+        # oblate control, unchanged by the signed modulus
+        self.test('WGS84.Llat(45)',          E.Llat(45),          '4984944.3780', fmt='%.4f')
+        self.test('WGS84.auxRectifying(45)', E.auxRectifying(45), '44.855682',    fmt='%.6f')
+
         def _auX(aux, d, x, **kwds):
             a = aux(d, **kwds)
             t = fstr(a, prec=9)


### PR DESCRIPTION
`Ellipsoid._elliptic_e22` builds the meridian-arc `Elliptic` from the **unsigned** second eccentricity squared, `Elliptic(-self.e22abs)`. The meridian arc `ds/dβ = b·√(1 + e22·sin²β)` needs the **signed** modulus `k² = -e22`; `-e22abs` is only right when `e22 > 0`. For every prolate ellipsoid (`f < 0`, so `e22 < 0`) it flips the sign under the radical, so the whole rectifying/meridian class — `L` (quarter meridian), `Llat`/`Lmeridian`, `auxRectifying` forward and inverse, and `polarimeter` — is off by ~0.34% (~33 km) even at a mild `f = -0.0034`, up to 34% at `f = -0.5`. Oblate ellipsoids are unaffected, since there `-e22 == -e22abs`, which is why it went unnoticed.

One line, matching the correct sibling `_elliptic_e12` (which already uses the signed `e2/(e2 - 1) == -e22`):

```diff
-        return _MODS.elliptic.Elliptic(-self.e22abs)  # complex
+        return _MODS.elliptic.Elliptic(-self.e22)  # signed, like ._elliptic_e12
```

The signed modulus is confirmed three ways already in the tree/upstream: the `L` docstring's own `b * Elliptic(-e2 / (1 - e2)).cE` (i.e. `Elliptic(-e22)`), the sibling `_elliptic_e12`, and GeographicLib's `Ellipsoid` `EllipticFunction _ell(-_e12)` with `_e12 = _e2/(1 - _e2)`.

Repro — a prolate ellipsoid is WGS84 with the axes swapped, i.e. the same meridian ellipse, so its quarter meridian must equal WGS84's:

```python
>>> from pygeodesy import Ellipsoid, Ellipsoids
>>> W = Ellipsoids.WGS84
>>> P = Ellipsoid(W.b, W.a, name='Prolate')
>>> P.L, W.L
(10035500.520450..., 10001965.729312...)   # before: 33.5 km too long
# after the fix: P.L == W.L == 10001965.7293
```

The existing `Prolate` `auxRectifying` checks in `testEllipsoids.py` are `self.test(t, t)` tautologies plus a round-trip closure — forward and inverse share the modulus, so it stays closed — which is why the error was invisible. The added `Prolate meridian` tests pin `L`, `Llat`, `auxRectifying` (forward + inverse) and `polarimeter` on a mild and a strongly prolate ellipsoid against an independent arc-length oracle, with a WGS84 oblate control. `testEllipsoids.py` stays at 77 known failures; `testRhumb_*`, `testGeodesicx` and `testUtmups` are unchanged (`Rhumb` already uses the signed `_elliptic_e12`).

Sibling of #85, which fixed a different prolate meridian issue in `geodesicx/gx.py`.
